### PR TITLE
Suppress Affirm payment for non "in stock" items

### DIFF
--- a/cartridges/int_affirm/cartridge/scripts/data/affirmData.js
+++ b/cartridges/int_affirm/cartridge/scripts/data/affirmData.js
@@ -122,6 +122,16 @@
             return !!currentSite.getCustomPreferenceValue('AffirmProductMessage');
         };
         /**
+         * Return in-stock items only preference
+         *
+         * @returns {boolean} in-stock only preference
+         */
+        this.getShowInStockOnly = function () {
+            return !empty(currentSite.getCustomPreferenceValue('AffirmShowInStockOnly')) 
+                ? currentSite.getCustomPreferenceValue('AffirmShowInStockOnly') 
+                : false;
+        };
+        /**
          * Return financing program to cart total mapping
          *
          * @returns {array} array of string

--- a/cartridges/int_affirm/cartridge/templates/resources/affirm.properties
+++ b/cartridges/int_affirm/cartridge/templates/resources/affirm.properties
@@ -22,5 +22,6 @@ basket.giftcertificate.present=To proceed with Affirm payment, please remove Gif
 payment.learnmore=Learn more
 payment.monthlypayments=Monthly Payments
 payment.info=You will be redirected to Affirm to securely complete your purchase. Just fill out a few pieces of basic information and get a real-time decision. Checking your eligibility won't affect your credit score.
+payment.info.oos=Affirm is not available for items on pre-order or backorder.
 payment.name=Affirm
 shipping.surcharge=(with surcharge)

--- a/cartridges/int_affirm_controllers/cartridge/templates/default/affirm/paymentmethodinput.isml
+++ b/cartridges/int_affirm_controllers/cartridge/templates/default/affirm/paymentmethodinput.isml
@@ -1,4 +1,23 @@
-<isif condition="${!require('*/cartridge/scripts/data/affirmData').getAffirmPaymentOnlineStatus()}">
+<isset name="affirmData" value="${require('*/cartridge/scripts/data/affirmData')}" scope="page" />
+<isscript>
+	var plis = pdict.Basket.getAllProductLineItems();
+	var inStockCheckout = true;
+	for (var i = 0; i < plis.length; i++) {
+		var pli = plis[i]
+		var isInStock = pli.product.availabilityModel.inStock
+		if (isInStock) { continue; } 
+		else {
+			inStockCheckout = false;
+			break;
+		}
+	}
+</isscript>
+<isif condition="${affirmData.getPromoMessageInStockOnly()}">
+	<isset name="showInStockCheckout" value="${inStockCheckout}" scope="page"/>
+<iselse>
+	<isset name="showInStockCheckout" value="${true}" scope="page"/>
+</isif>
+<isif condition="${!require('*/cartridge/scripts/data/affirmData').getAffirmPaymentOnlineStatus() && showInStockCheckout}">
 <div class="form-row label-inline affirm-payment-method">
 	<isset name="radioID" value="${paymentMethodType.value}" scope="page"/>
 	<div class="field-wrapper">

--- a/cartridges/int_affirm_controllers/cartridge/templates/default/affirm/paymentmethodinput.isml
+++ b/cartridges/int_affirm_controllers/cartridge/templates/default/affirm/paymentmethodinput.isml
@@ -12,7 +12,7 @@
 		}
 	}
 </isscript>
-<isif condition="${affirmData.getPromoMessageInStockOnly()}">
+<isif condition="${affirmData.getShowInStockOnly()}">
 	<isset name="showInStockCheckout" value="${inStockCheckout}" scope="page"/>
 <iselse>
 	<isset name="showInStockCheckout" value="${true}" scope="page"/>

--- a/cartridges/int_affirm_controllers/cartridge/templates/default/affirm/paymentmethodinput.isml
+++ b/cartridges/int_affirm_controllers/cartridge/templates/default/affirm/paymentmethodinput.isml
@@ -17,11 +17,14 @@
 <iselse>
 	<isset name="showInStockCheckout" value="${true}" scope="page"/>
 </isif>
-<isif condition="${!require('*/cartridge/scripts/data/affirmData').getAffirmPaymentOnlineStatus() && showInStockCheckout}">
+<isif condition="${!require('*/cartridge/scripts/data/affirmData').getAffirmPaymentOnlineStatus()}">
 <div class="form-row label-inline affirm-payment-method">
 	<isset name="radioID" value="${paymentMethodType.value}" scope="page"/>
 	<div class="field-wrapper">
-		<input id="is-${radioID}" type="radio" class="input-radio" name="${pdict.CurrentForms.billing.paymentMethods.selectedPaymentMethodID.htmlName}" value="${paymentMethodType.htmlValue}" <isif condition="${paymentMethodType.value == pdict.CurrentForms.billing.paymentMethods.selectedPaymentMethodID.htmlValue}">checked="checked"</isif> />
+		<input id="is-${radioID}" type="radio" class="input-radio" name="${pdict.CurrentForms.billing.paymentMethods.selectedPaymentMethodID.htmlName}" value="${paymentMethodType.htmlValue}" 
+			<isif condition="${paymentMethodType.value == pdict.CurrentForms.billing.paymentMethods.selectedPaymentMethodID.htmlValue}">checked="checked"</isif> 
+			<isif condition="${!showInStockCheckout}">disabled</isif> 
+		/>
 		<label for="is-${radioID}" class="field-label">
 			<img alt="${Resource.msg(paymentMethodType.label,'forms',null)}" 
 				src="https://cdn-assets.affirm.com/images/blue_logo-transparent_bg.png" 
@@ -32,6 +35,10 @@
 			>${Resource.msg('payment.learnmore', 'affirm', null)}</a>
 		</label>
 	</div>
-	${Resource.msg('payment.info', 'affirm', null)}
+	<isif condition="${showInStockCheckout}">
+		${Resource.msg('payment.info', 'affirm', null)}    
+	<iselse/>
+		${Resource.msg('payment.info.oos', 'affirm', null)}    
+	</isif>
 </div>
 </isif>

--- a/cartridges/int_affirm_controllers/cartridge/templates/default/util/affirmpromo.isml
+++ b/cartridges/int_affirm_controllers/cartridge/templates/default/util/affirmpromo.isml
@@ -4,7 +4,25 @@
 <isif condition="${pdict.fpname}">
 	<isset name="promoModal" value="${affirmUtils.getPromoModalByFinProgramName(pdict.fpname)}" scope="page"/>
 </isif>
-<isif condition="${pdict.context == 'cart' && affirmData.getCartPromoMessageStatus()}">
+<isscript>
+	var plis = pdict.Basket.getAllProductLineItems();
+	var inStockCart = true;
+	for (var i = 0; i < plis.length; i++) {
+		var pli = plis[i]
+		var isInStock = pli.product.availabilityModel.inStock
+		if (isInStock) { continue; } 
+		else {
+			inStockCart = false;
+			break;
+		}
+	}
+</isscript>
+<isif condition="${affirmData.getShowInStockOnly()}">
+	<isset name="showInStockCart" value="${inStockCart}" scope="page"/>
+<iselse>
+	<isset name="showInStockCart" value="${true}" scope="page"/>
+</isif>
+<isif condition="${pdict.context == 'cart' && affirmData.getCartPromoMessageStatus() && showInStockCart}">
 	<isif condition="${pdict.Basket.totalGrossPrice.available}">
 		<isset name="basketTotal" value="${pdict.Basket.totalGrossPrice}" scope="page" />
 	<iselse>
@@ -21,7 +39,12 @@
 	<isif condition="${psTop}">
 		<isset name="product" value="${pdict.Product}" scope="page"/>
 	</isif>
-	<isif condition="${!empty(product)}">
+	<isif condition="${affirmData.getShowInStockOnly()}">
+		<isset name="showInStockPDP" value="${pdict.Product.availabilityModel.inStock}" scope="page"/>
+	<iselse>
+		<isset name="showInStockPDP" value="${true}" scope="page"/>
+	</isif>
+	<isif condition="${!empty(product) && showInStockPDP}">
 		<isset name="productPriceModel" value="${product.priceModel}" scope="page"/>
 		<isif condition="${product.productSet}">
 			<isset name="price" value="${affirmUtils.calculateProductSetPrice(product)}" scope="page"/>

--- a/cartridges/int_affirm_pipelines/cartridge/templates/default/affirm/paymentmethodinput.isml
+++ b/cartridges/int_affirm_pipelines/cartridge/templates/default/affirm/paymentmethodinput.isml
@@ -1,4 +1,23 @@
-<isif condition="${!require('*/cartridge/scripts/data/affirmData').getAffirmPaymentOnlineStatus()}">
+<isset name="affirmData" value="${require('*/cartridge/scripts/data/affirmData')}" scope="page" />
+<isscript>
+	var plis = pdict.Basket.getAllProductLineItems();
+	var inStockCheckout = true;
+	for (var i = 0; i < plis.length; i++) {
+		var pli = plis[i]
+		var isInStock = pli.product.availabilityModel.inStock
+		if (isInStock) { continue; } 
+		else {
+			inStockCheckout = false;
+			break;
+		}
+	}
+</isscript>
+<isif condition="${affirmData.getPromoMessageInStockOnly()}">
+	<isset name="showInStockCheckout" value="${inStockCheckout}" scope="page"/>
+<iselse>
+	<isset name="showInStockCheckout" value="${true}" scope="page"/>
+</isif>
+<isif condition="${!require('*/cartridge/scripts/data/affirmData').getAffirmPaymentOnlineStatus() && showInStockCheckout}">
 <div class="form-row label-inline affirm-payment-method">
 	<isset name="radioID" value="${paymentMethodType.value}" scope="page"/>
 	<div class="field-wrapper">

--- a/cartridges/int_affirm_pipelines/cartridge/templates/default/affirm/paymentmethodinput.isml
+++ b/cartridges/int_affirm_pipelines/cartridge/templates/default/affirm/paymentmethodinput.isml
@@ -12,7 +12,7 @@
 		}
 	}
 </isscript>
-<isif condition="${affirmData.getPromoMessageInStockOnly()}">
+<isif condition="${affirmData.getShowInStockOnly()}">
 	<isset name="showInStockCheckout" value="${inStockCheckout}" scope="page"/>
 <iselse>
 	<isset name="showInStockCheckout" value="${true}" scope="page"/>

--- a/cartridges/int_affirm_pipelines/cartridge/templates/default/affirm/paymentmethodinput.isml
+++ b/cartridges/int_affirm_pipelines/cartridge/templates/default/affirm/paymentmethodinput.isml
@@ -17,11 +17,14 @@
 <iselse>
 	<isset name="showInStockCheckout" value="${true}" scope="page"/>
 </isif>
-<isif condition="${!require('*/cartridge/scripts/data/affirmData').getAffirmPaymentOnlineStatus() && showInStockCheckout}">
+<isif condition="${!require('*/cartridge/scripts/data/affirmData').getAffirmPaymentOnlineStatus()}">
 <div class="form-row label-inline affirm-payment-method">
 	<isset name="radioID" value="${paymentMethodType.value}" scope="page"/>
 	<div class="field-wrapper">
-		<input id="is-${radioID}" type="radio" class="input-radio" name="${pdict.CurrentForms.billing.paymentMethods.selectedPaymentMethodID.htmlName}" value="${paymentMethodType.htmlValue}" <isif condition="${paymentMethodType.value == pdict.CurrentForms.billing.paymentMethods.selectedPaymentMethodID.htmlValue}">checked="checked"</isif> />
+		<input id="is-${radioID}" type="radio" class="input-radio" name="${pdict.CurrentForms.billing.paymentMethods.selectedPaymentMethodID.htmlName}" value="${paymentMethodType.htmlValue}" 
+			<isif condition="${paymentMethodType.value == pdict.CurrentForms.billing.paymentMethods.selectedPaymentMethodID.htmlValue}">checked="checked"</isif> 
+			<isif condition="${!showInStockCheckout}">disabled</isif> 
+		/>
 		<label for="is-${radioID}" class="field-label">
 			<img alt="${Resource.msg(paymentMethodType.label,'forms',null)}" 
 				src="https://cdn-assets.affirm.com/images/blue_logo-transparent_bg.png" 
@@ -32,6 +35,10 @@
 			>${Resource.msg('payment.learnmore', 'affirm', null)}</a>
 		</label>
 	</div>
-	${Resource.msg('payment.info', 'affirm', null)}
+	<isif condition="${showInStockCheckout}">
+		${Resource.msg('payment.info', 'affirm', null)}    
+	<iselse/>
+		${Resource.msg('payment.info.oos', 'affirm', null)}    
+	</isif>
 </div>
 </isif>

--- a/cartridges/int_affirm_pipelines/cartridge/templates/default/util/affirmpromo.isml
+++ b/cartridges/int_affirm_pipelines/cartridge/templates/default/util/affirmpromo.isml
@@ -4,8 +4,25 @@
 <isif condition="${pdict.fpname}">
 	<isset name="promoModal" value="${affirmUtils.getPromoModalByFinProgramName(pdict.fpname)}" scope="page"/>
 </isif>
-
-<isif condition="${pdict.context == 'cart' && affirmData.getCartPromoMessageStatus()}">
+<isscript>
+	var plis = pdict.Basket.getAllProductLineItems();
+	var inStockCart = true;
+	for (var i = 0; i < plis.length; i++) {
+		var pli = plis[i]
+		var isInStock = pli.product.availabilityModel.inStock
+		if (isInStock) { continue; } 
+		else {
+			inStockCart = false;
+			break;
+		}
+	}
+</isscript>
+<isif condition="${affirmData.getShowInStockOnly()}">
+	<isset name="showInStockCart" value="${inStockCart}" scope="page"/>
+<iselse>
+	<isset name="showInStockCart" value="${true}" scope="page"/>
+</isif>
+<isif condition="${pdict.context == 'cart' && affirmData.getCartPromoMessageStatus() && showInStockCart}">
 	<isif condition="${pdict.Basket.totalGrossPrice.available}">
 		<isset name="basketTotal" value="${pdict.Basket.totalGrossPrice}" scope="page" />
 	<iselse>
@@ -22,7 +39,12 @@
 	<isif condition="${psTop}">
 		<isset name="product" value="${pdict.Product}" scope="page"/>
 	</isif>
-	<isif condition="${!empty(product)}">
+	<isif condition="${affirmData.getShowInStockOnly()}">
+		<isset name="showInStockPDP" value="${pdict.Product.availabilityModel.inStock}" scope="page"/>
+	<iselse>
+		<isset name="showInStockPDP" value="${true}" scope="page"/>
+	</isif>
+	<isif condition="${!empty(product) && showInStockPDP}">
 		<isset name="productPriceModel" value="${product.priceModel}" scope="page"/>
 		<isif condition="${product.productSet}">
 			<isset name="price" value="${affirmUtils.calculateProductSetPrice(product)}" scope="page"/>

--- a/cartridges/int_affirm_pipelines/cartridge/templates/resources/affirm.properties
+++ b/cartridges/int_affirm_pipelines/cartridge/templates/resources/affirm.properties
@@ -23,6 +23,7 @@ affirm.error.default=Please try a different payment method
 payment.learnmore=Learn more
 payment.monthlypayments=Monthly Payments
 payment.info=You will be redirected to Affirm to securely complete your purchase. Just fill out a few pieces of basic information and get a real-time decision. Checking your eligibility won't affect your credit score.
+payment.info.oos=Affirm is not available for items on pre-order or backorder.
 payment.name=Affirm
 shipping.surcharge=(with surcharge)
 affirm.controllers.cartridge=app_storefront_controllers

--- a/cartridges/int_affirm_sfra/cartridge/client/default/js/checkout/checkout.js
+++ b/cartridges/int_affirm_sfra/cartridge/client/default/js/checkout/checkout.js
@@ -290,6 +290,11 @@ var scrollAnimate = require('base/components/scrollAnimate');
 
                                 defer.reject();
                             } else {
+                                // Disable Affirm for preorder/backordered items
+                                if ($('fieldset.affirm-form').data('affirm-suppressed') && $('.affirm-payment-tab').hasClass('active')) {
+                                    $('.affirm-not-available').addClass('alert-danger');
+                                    defer.reject();
+                                }
                                 //
                                 // Populate the Address Summary
                                 //

--- a/cartridges/int_affirm_sfra/cartridge/templates/default/affirm/paymentMethodInputMF.isml
+++ b/cartridges/int_affirm_sfra/cartridge/templates/default/affirm/paymentMethodInputMF.isml
@@ -1,20 +1,35 @@
+<isset name="affirmData" value="${require('*/cartridge/scripts/data/affirmData')}" scope="page" />
+<isset name="inStockLabel" value="${require('dw/web/Resource').msg('label.instock', 'common', null)}" scope="page" />
+<isscript>
+    var plis = pdict.order.items.items;
+    var inStockCheckout = true;
+    for (var i = 0; i < plis.length; i++) {
+        var pli = plis[i]
+        inStockCheckout = pli.availability.messages.every(function(e) { return e === inStockLabel })
+        if (!inStockCheckout) break;
+    }
+</isscript>
+<isset name="showInStockCheckout" value="${affirmData.getShowInStockOnly() ? inStockCheckout : true}" scope="page"/>
+
 <div class="tab-pane affirm-payment-content" id="affirm-payment-content" role="tabpanel">
-	<fieldset class="payment-form-fields affirm-form">
+	<fieldset class="payment-form-fields affirm-form" data-affirm-suppressed="${!showInStockCheckout}">
 		<input type="hidden" class="form-control"
            name="${pdict.forms.billingForm.paymentMethod.htmlName}"
            value="Affirm">
-
-			<label for="affirmPayment" class="field-label">
-				<img class="payment-description-logo-affirm"
-				    alt="${Resource.msg('paymentMethodType.label','forms',null)}"
-					src="https://cdn-assets.affirm.com/images/blue_logo-transparent_bg.png"
-					title="${Resource.msg('paymentMethodType.label','forms',null)}"/>
-				<span>${Resource.msg('payment.monthlypayments', 'affirm', null)}</span>
-				<a class="affirm-product-modal" style="" data-amount="${require('dw/order/BasketMgr').currentBasket.totalGrossPrice.multiply(100).getValue().toFixed()}"
-				>${Resource.msg('payment.learnmore', 'affirm', null)}</a>
-			</label>
-			
-		${Resource.msg('payment.info', 'affirm', null)}
+			<isif condition="${showInStockCheckout}">
+				<label for="affirmPayment" class="field-label">
+					<img class="payment-description-logo-affirm"
+							alt="${Resource.msg('paymentMethodType.label','forms',null)}"
+						src="https://cdn-assets.affirm.com/images/blue_logo-transparent_bg.png"
+						title="${Resource.msg('paymentMethodType.label','forms',null)}"/>
+					<span>${Resource.msg('payment.monthlypayments', 'affirm', null)}</span>
+					<a class="affirm-product-modal" style="" data-amount="${require('dw/order/BasketMgr').currentBasket.totalGrossPrice.multiply(100).getValue().toFixed()}"
+					>${Resource.msg('payment.learnmore', 'affirm', null)}</a>
+				</label>
+				<p style="padding: .5rem; border-radius: .1875rem">${Resource.msg('payment.info', 'affirm', null)}</p>
+			<iselse/>
+				<p style="padding: .5rem; border-radius: .1875rem" class="affirm-not-available">${Resource.msg('payment.info.oos', 'affirm', null)}</p>
+			</isif>
 		
 	   </fieldset>
 		 <isset name="affirm" value="${require('*/cartridge/scripts/affirm')}" scope="page" />

--- a/cartridges/int_affirm_sfra/cartridge/templates/default/checkout/billing/paymentOptions/paymentOptionsTabs.isml
+++ b/cartridges/int_affirm_sfra/cartridge/templates/default/checkout/billing/paymentOptions/paymentOptionsTabs.isml
@@ -1,18 +1,5 @@
-<isset name="affirmData" value="${require('*/cartridge/scripts/data/affirmData')}" scope="page" />
-<isset name="inStockLabel" value="${require('dw/web/Resource').msg('label.instock', 'common', null)}" scope="page" />
-<isscript>
-    var plis = pdict.order.items.items;
-    var inStockCheckout = true;
-    for (var i = 0; i < plis.length; i++) {
-        var pli = plis[i]
-        inStockCheckout = pli.availability.messages.every(function(e) { return e === inStockLabel })
-        if (!inStockCheckout) break;
-    }
-</isscript>
-<isset name="showInStockCheckout" value="${affirmData.getShowInStockOnly() ? inStockCheckout : true}" scope="page"/>
-
 <isloop items="${pdict.order.billing.payment.applicablePaymentMethods}" var="paymentOption">
-    <isif condition="${paymentOption.ID === 'Affirm' && require('*/cartridge/scripts/utils/affirmHelper').IsAffirmApplicable() && showInStockCheckout}">
+    <isif condition="${paymentOption.ID === 'Affirm' && require('*/cartridge/scripts/utils/affirmHelper').IsAffirmApplicable()}">
        <isinclude template="affirm/affirmpaymethodli" />
     </isif>
     <isif condition="${paymentOption.ID === 'CREDIT_CARD'}">

--- a/cartridges/int_affirm_sfra/cartridge/templates/default/checkout/billing/paymentOptions/paymentOptionsTabs.isml
+++ b/cartridges/int_affirm_sfra/cartridge/templates/default/checkout/billing/paymentOptions/paymentOptionsTabs.isml
@@ -1,6 +1,19 @@
+<isset name="affirmData" value="${require('*/cartridge/scripts/data/affirmData')}" scope="page" />
+<isset name="inStockLabel" value="${require('dw/web/Resource').msg('label.instock', 'common', null)}" scope="page" />
+<isscript>
+    var plis = pdict.order.items.items;
+    var inStockCheckout = true;
+    for (var i = 0; i < plis.length; i++) {
+        var pli = plis[i]
+        inStockCheckout = pli.availability.messages.every(function(e) { return e === inStockLabel })
+        if (!inStockCheckout) break;
+    }
+</isscript>
+<isset name="showInStockCheckout" value="${affirmData.getShowInStockOnly() ? inStockCheckout : true}" scope="page"/>
+
 <isloop items="${pdict.order.billing.payment.applicablePaymentMethods}" var="paymentOption">
-    <isif condition="${paymentOption.ID === 'Affirm' && require('*/cartridge/scripts/utils/affirmHelper').IsAffirmApplicable()}">
-       <isinclude template="affirm/affirmPayMethodLi" />
+    <isif condition="${paymentOption.ID === 'Affirm' && require('*/cartridge/scripts/utils/affirmHelper').IsAffirmApplicable() && showInStockCheckout}">
+       <isinclude template="affirm/affirmpaymethodli" />
     </isif>
     <isif condition="${paymentOption.ID === 'CREDIT_CARD'}">
         <isinclude template="checkout/billing/paymentOptions/creditCardTab" />

--- a/cartridges/int_affirm_sfra/cartridge/templates/default/util/affirmPromo.isml
+++ b/cartridges/int_affirm_sfra/cartridge/templates/default/util/affirmPromo.isml
@@ -1,11 +1,22 @@
 <isset name="affirmData" value="${require('*/cartridge/scripts/data/affirmData')}" scope="page" />
 <isset name="affirmUtils" value="${require('*/cartridge/scripts/utils/affirmUtils')}" scope="page" />
 <isset name="promoModal" value="${''}" scope="page"/>
+<isset name="inStockLabel" value="${require('dw/web/Resource').msg('label.instock', 'common', null)}" scope="page" />
 
 <isif condition="${pdict.fpname}">
 	<isset name="promoModal" value="${affirmUtils.getPromoModalByFinProgramName(pdict.fpname)}" scope="page"/>
 </isif>
-<isif condition="${pdict.context == 'cart' && affirmData.getCartPromoMessageStatus()}">
+<isscript>
+	var plis = pdict.items;
+	var inStockCart = true;
+	for (var i = 0; i < plis.length; i++) {
+		var pli = plis[i]
+		inStockCart = pli.availability.messages.every(function(e) { return e === inStockLabel })
+		if (!inStockCart) break;
+	}
+</isscript>
+<isset name="showInStockCart" value="${affirmData.getShowInStockOnly() ? inStockCart : true}" scope="page"/>
+<isif condition="${pdict.context == 'cart' && affirmData.getCartPromoMessageStatus() && showInStockCart}">
 	<isif condition="${Basket.totalGrossPrice.available}">
 		<isset name="basketTotal" value="${Basket.totalGrossPrice}" scope="page" />
 	<iselse>
@@ -27,7 +38,11 @@
 	<iselse>
 		<isset name="productValue" value="" scope="page"/>
 	</isif>
-	<isif condition="${!empty(productValue)}">
+	<isscript>
+		var inStockPDP = pdict.product.availability.messages.every(function(e) { return e === inStockLabel })
+	</isscript>
+	<isset name="showInStockPDP" value="${affirmData.getShowInStockOnly() ? inStockPDP : true}" scope="page"/>
+	<isif condition="${!empty(productValue) && showInStockPDP}">
 		<isset name="productPriceModel" value="${productValue.priceModel}" scope="page"/>
 		<isif condition="${Product.productSet}">
 			<isset name="price" value="${affirmUtils.calculateProductSetPrice(Product)}" scope="page"/>

--- a/metadata/affirm/meta/system-objecttype-extensions.xml
+++ b/metadata/affirm/meta/system-objecttype-extensions.xml
@@ -362,6 +362,13 @@ Example: 50|90|smallOrderFP</description>
                 <externally-managed-flag>false</externally-managed-flag>
                 <default-value>false</default-value>
             </attribute-definition>
+            <attribute-definition attribute-id="AffirmShowInStockOnly">
+                <display-name xml:lang="x-default">Enable Affirm for In-stock Items Only</display-name>
+                <type>boolean</type>
+                <mandatory-flag>false</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+                <default-value>false</default-value>
+            </attribute-definition>
             <attribute-definition attribute-id="AffirmPublicKey">
                 <display-name xml:lang="x-default">Affirm Public Key</display-name>
                 <type>string</type>
@@ -439,6 +446,7 @@ Example: 50|90|smallOrderFP</description>
                 <attribute attribute-id="AffirmProductMessage"/>
                 <attribute attribute-id="AffirmCartPromoMessage"/>
                 <attribute attribute-id="AffirmPaymentOnlineStatus"/>
+                <attribute attribute-id="AffirmShowInStockOnly"/>
                 <attribute attribute-id="AffirmMinTotal"/>
                 <attribute attribute-id="AffirmFPMapping"/>
                 <attribute attribute-id="AffirmFPTotalRange"/>


### PR DESCRIPTION
In SFCC, the availability status of an item can be one of these three: `BACKORDER`, `IN_STOCK`, `NOT_AVAILABLE`, or `PREORDER`. 
This commit looks at the pdp, cart and checkout pages and suppress Affirm payment related modules for items that are not "in stock". 