### PR TITLE
Checkout promo message

### DIFF
--- a/cartridges/int_affirm/cartridge/templates/resources/affirm.properties
+++ b/cartridges/int_affirm/cartridge/templates/resources/affirm.properties
@@ -20,7 +20,6 @@ basket.changed.error=Basket has been changed. Please proceed with checkout again
 basket.giftcertificate.present=To proceed with Affirm payment, please remove Gift Certificates from the Cart.
 
 payment.learnmore=Learn more
-payment.monthlypayments=Monthly Payments
 payment.info=You will be redirected to Affirm to securely complete your purchase. Just fill out a few pieces of basic information and get a real-time decision. Checking your eligibility won't affect your credit score.
 payment.info.oos=Affirm is not available for items on pre-order or backorder.
 payment.name=Affirm

--- a/cartridges/int_affirm_controllers/cartridge/static/default/css/affirmstyle.css
+++ b/cartridges/int_affirm_controllers/cartridge/static/default/css/affirmstyle.css
@@ -16,15 +16,6 @@
 	width: 4.5rem;
 }
 
-.affirm-payment-method.form-row .field-wrapper .field-label span{
-	vertical-align: 70%;
-}
-
-.affirm-payment-method.form-row .field-wrapper .field-label a{
-	display: inline-block;
-	vertical-align: 50%;
-}
-
 .affirm-as-low-as {
 	height: 3.25rem;
 	padding-bottom: 1rem;

--- a/cartridges/int_affirm_controllers/cartridge/templates/default/affirm/paymentmethodinput.isml
+++ b/cartridges/int_affirm_controllers/cartridge/templates/default/affirm/paymentmethodinput.isml
@@ -25,14 +25,10 @@
 			<isif condition="${paymentMethodType.value == pdict.CurrentForms.billing.paymentMethods.selectedPaymentMethodID.htmlValue}">checked="checked"</isif> 
 			<isif condition="${!showInStockCheckout}">disabled</isif> 
 		/>
-		<label for="is-${radioID}" class="field-label">
-			<img alt="${Resource.msg(paymentMethodType.label,'forms',null)}" 
-				src="https://cdn-assets.affirm.com/images/blue_logo-transparent_bg.png" 
-				title="${Resource.msg(paymentMethodType.label,'forms',null)}"/>
-			<span>${Resource.msg('payment.monthlypayments', 'affirm', null)}</span>
-			<a class="affirm-product-modal" style=""
+		<label for="is-${radioID}" class="field-label" style="float: none;">
+			<span class="affirm-as-low-as" data-page-type="payment" 
 			data-amount="${pdict.Basket.totalGrossPrice.multiply(100).getValue().toFixed()}"
-			>${Resource.msg('payment.learnmore', 'affirm', null)}</a>
+			></span>
 		</label>
 	</div>
 	<isif condition="${showInStockCheckout}">

--- a/cartridges/int_affirm_pipelines/cartridge/static/default/css/affirmstyle.css
+++ b/cartridges/int_affirm_pipelines/cartridge/static/default/css/affirmstyle.css
@@ -16,15 +16,6 @@
 	width: 4.5rem;
 }
 
-.affirm-payment-method.form-row .field-wrapper .field-label span{
-	vertical-align: 70%;
-}
-
-.affirm-payment-method.form-row .field-wrapper .field-label a{
-	display: inline-block;
-	vertical-align: 50%;
-}
-
 .affirm-as-low-as {
 	height: 3.25rem;
 	padding-bottom: 1rem;

--- a/cartridges/int_affirm_pipelines/cartridge/templates/default/affirm/paymentmethodinput.isml
+++ b/cartridges/int_affirm_pipelines/cartridge/templates/default/affirm/paymentmethodinput.isml
@@ -25,14 +25,10 @@
 			<isif condition="${paymentMethodType.value == pdict.CurrentForms.billing.paymentMethods.selectedPaymentMethodID.htmlValue}">checked="checked"</isif> 
 			<isif condition="${!showInStockCheckout}">disabled</isif> 
 		/>
-		<label for="is-${radioID}" class="field-label">
-			<img alt="${Resource.msg(paymentMethodType.label,'forms',null)}" 
-				src="https://cdn-assets.affirm.com/images/blue_logo-transparent_bg.png" 
-				title="${Resource.msg(paymentMethodType.label,'forms',null)}"/>
-			<span>${Resource.msg('payment.monthlypayments', 'affirm', null)}</span>
-			<a class="affirm-product-modal" style=""
+		<label for="is-${radioID}" class="field-label" style="float: none;">
+			<span class="affirm-as-low-as" data-page-type="payment" 
 			data-amount="${pdict.Basket.totalGrossPrice.multiply(100).getValue().toFixed()}"
-			>${Resource.msg('payment.learnmore', 'affirm', null)}</a>
+			></span>
 		</label>
 	</div>
 	<isif condition="${showInStockCheckout}">

--- a/cartridges/int_affirm_pipelines/cartridge/templates/resources/affirm.properties
+++ b/cartridges/int_affirm_pipelines/cartridge/templates/resources/affirm.properties
@@ -21,7 +21,6 @@ basket.giftcertificate.present=To proceed with Affirm payment, please remove Gif
 affirm.error.closed=Payment window was closed
 affirm.error.default=Please try a different payment method
 payment.learnmore=Learn more
-payment.monthlypayments=Monthly Payments
 payment.info=You will be redirected to Affirm to securely complete your purchase. Just fill out a few pieces of basic information and get a real-time decision. Checking your eligibility won't affect your credit score.
 payment.info.oos=Affirm is not available for items on pre-order or backorder.
 payment.name=Affirm

--- a/cartridges/int_affirm_sfra/cartridge/templates/default/affirm/paymentMethodInputMF.isml
+++ b/cartridges/int_affirm_sfra/cartridge/templates/default/affirm/paymentMethodInputMF.isml
@@ -18,13 +18,7 @@
            value="Affirm">
 			<isif condition="${showInStockCheckout}">
 				<label for="affirmPayment" class="field-label">
-					<img class="payment-description-logo-affirm"
-							alt="${Resource.msg('paymentMethodType.label','forms',null)}"
-						src="https://cdn-assets.affirm.com/images/blue_logo-transparent_bg.png"
-						title="${Resource.msg('paymentMethodType.label','forms',null)}"/>
-					<span>${Resource.msg('payment.monthlypayments', 'affirm', null)}</span>
-					<a class="affirm-product-modal" style="" data-amount="${require('dw/order/BasketMgr').currentBasket.totalGrossPrice.multiply(100).getValue().toFixed()}"
-					>${Resource.msg('payment.learnmore', 'affirm', null)}</a>
+					<span style="display: inline-block; padding: .5rem; height: auto;" class="affirm-as-low-as" data-page-type="payment" data-amount="${require('dw/order/BasketMgr').currentBasket.totalGrossPrice.multiply(100).getValue().toFixed()}"></span>
 				</label>
 				<p style="padding: .5rem; border-radius: .1875rem">${Resource.msg('payment.info', 'affirm', null)}</p>
 			<iselse/>


### PR DESCRIPTION
Removes the static "monthly payments" messaging on checkout page as well as static affirm logo in the payment option div. It instead adds the `affirm-as-low-as` class and `payment` page-type data to dynamically populate promo messages on the checkout page. 

_Note: Messaging depends on the financing program and merchant configuration._

### SiteGenesis
<img width="527" alt="Screen Shot 2020-10-12 at 3 12 11 PM" src="https://user-images.githubusercontent.com/9426310/95794863-c174fb00-0c9d-11eb-9e86-64da45000aeb.png">

### SFRA
<img width="561" alt="Screen Shot 2020-10-12 at 2 16 45 PM" src="https://user-images.githubusercontent.com/9426310/95794886-cd60bd00-0c9d-11eb-8fdf-76ff6158b11f.png">
