### PR TITLE
Transactions API

### DIFF
--- a/cartridges/int_affirm/cartridge/scripts/api/affirmAPI.js
+++ b/cartridges/int_affirm/cartridge/scripts/api/affirmAPI.js
@@ -19,9 +19,9 @@
         self.auth = function (token) {
             try {
                 var affirmService = require('*/cartridge/scripts/init/initAffirmServices').initService('affirm.auth');
-                affirmService.URL = affirmData.getURLPath() + 'charges';
+                affirmService.URL = affirmData.getURLPath() + '/v1/transactions';
                 return affirmService.call({
-                    'checkout_token': token
+                    'transaction_id': token
                 }).object;
             } catch (e) {
                 logger.error('Affirm. File - affirmAPI. Error - {0}', e);
@@ -40,7 +40,7 @@
         self.capture = function (chargeId, captureData) {
             try {
                 var affirmService = require('*/cartridge/scripts/init/initAffirmServices').initService('affirm.capture');
-                affirmService.URL = affirmData.getURLPath() + 'charges/' + chargeId + '/capture';
+                affirmService.URL = affirmData.getURLPath() + '/v1/transactions/' + chargeId + '/capture';
                 return affirmService.call({
                     'order_id' : captureData
                 }).object;
@@ -58,7 +58,7 @@
         self.void = function (chargeId) {
             try {
                 var affirmService = require('*/cartridge/scripts/init/initAffirmServices').initService('affirm.void');
-                affirmService.URL = affirmData.getURLPath() + 'charges/' + chargeId + '/void';
+                affirmService.URL = affirmData.getURLPath() + '/v1/transactions/' + chargeId + '/void';
                 return affirmService.call().object;
             } catch (e) {
                 logger.error('Affirm. File - affirmAPI. Error - {0}', e);
@@ -77,7 +77,7 @@
             try {
                 var affirmService = require('*/cartridge/scripts/init/initAffirmServices').initService('affirm.refund');
                     
-                affirmService.URL = affirmData.getURLPath() + 'charges/' + chargeId + '/refund';
+                affirmService.URL = affirmData.getURLPath() + '/v1/transactions/' + chargeId + '/refund';
                 
                 return affirmService.call().object;
             } catch (e) {
@@ -95,7 +95,7 @@
         self.update = function (chargeId, updateData) {
             try {
                 var affirmService = require('*/cartridge/scripts/init/initAffirmServices').initService('affirm.update');
-                affirmService.URL = affirmData.getURLPath() + 'charges/' + chargeId + '/update';
+                affirmService.URL = affirmData.getURLPath() + '/v1/transactions/' + chargeId + '/update';
                 return affirmService.call(updateData).object;
             } catch (e) {
                 logger.error('Affirm. File - affirmAPI. Error - {0}', e);

--- a/cartridges/int_affirm/cartridge/scripts/utils/affirmUtils.js
+++ b/cartridges/int_affirm/cartridge/scripts/utils/affirmUtils.js
@@ -55,7 +55,7 @@
         self.checkTotalPrice = function (basket, AffirmResponse, status) {
             let totalPrice = self.calculateNonGiftCertificateAmount(basket).multiply(100).getValue();
             var logger = system.Logger.getLogger('Affirm', '');
-            if (totalPrice !== AffirmResponse.details.total) {
+            if (totalPrice !== AffirmResponse.amount) {
                 logger.error('Affirm check total price is failing');
                 status.addItem(
                     new system.StatusItem(

--- a/cartridges/int_affirm/cartridge/templates/resources/affirm.properties
+++ b/cartridges/int_affirm/cartridge/templates/resources/affirm.properties
@@ -2,9 +2,9 @@ metadata.platform_type=Demandware
 metadata.platform_affirm=20.3.0
 metadata.merchant.name=Test Merchant
 
-affirm.production.url=https://api.affirm.com/api/v2/
+affirm.production.url=https://api.affirm.com/api
 affirm.production.js=https://cdn1.affirm.com/js/v2/affirm.js
-affirm.sandbox.url=https://sandbox.affirm.com/api/v2/
+affirm.sandbox.url=https://sandbox.affirm.com/api
 affirm.sandbox.js=https://cdn1-sandbox.affirm.com/js/v2/affirm.js
 affirm.sandbox.baseurl=https://sandbox.affirm.com
 

--- a/cartridges/int_affirm_pipelines/cartridge/templates/resources/affirm.properties
+++ b/cartridges/int_affirm_pipelines/cartridge/templates/resources/affirm.properties
@@ -2,9 +2,9 @@ metadata.platform_type=Demandware
 metadata.platform_affirm=20.3.0
 metadata.merchant.name=Test Merchant
 
-affirm.production.url=https://api.affirm.com/api/v2/
+affirm.production.url=https://api.affirm.com/api
 affirm.production.js=https://cdn1.affirm.com/js/v2/affirm.js
-affirm.sandbox.url=https://sandbox.affirm.com/api/v2/
+affirm.sandbox.url=https://sandbox.affirm.com/api
 affirm.sandbox.js=https://cdn1-sandbox.affirm.com/js/v2/affirm.js
 affirm.sandbox.baseurl=https://sandbox.affirm.com
 


### PR DESCRIPTION
### Description
Allowing Affirm cartridges to use [Transactions API](https://docs.affirm.com/affirm-developers/reference#merchant-transactions-api) which replaces the existing [Charges endpoints](https://docs.affirm.com/affirm-developers/reference#the-charge-object) while maintaining the same functionality. 

### Summary of changes
* Changed request URI paths for charge related actions (`api/v2/charges` -> `api/v1/transactions`) along with other parameter changes to use the Transactions API

### How to test
Place an order using Affirm payment and perform charge actions in Business Manager (capture, refund, update, etc)

### Benefits
Adds support to use the new Transactions API.