### PR TITLE
Disable partial capture for CA

### DIFF
--- a/cartridges/bm_affirm/cartridge/scripts/util/resource.js
+++ b/cartridges/bm_affirm/cartridge/scripts/util/resource.js
@@ -22,6 +22,7 @@ ResourceHelper.getResources = function () {
         TRANSACTION_FAILED: Resource.msg('transaction.failed', 'affirm', null),
         TRANSACTION_PROCESSING: Resource.msg('operations.wait', 'affirm', null),
         INVALID_CAPTURE_AMOUNT: Resource.msg('capture.amount.validation', 'affirm', null),
+        INVALID_CAPTURE_AMOUNT_PARTIAL: Resource.msg('capture.amount.validation.partial', 'affirm', null),
         INVALID_REFUND_AMOUNT: Resource.msg('refund.amount.validation', 'affirm', null),
         MAXIMUM_REFUND_AMOUNT: Resource.msg('maximum.refund.amount', 'affirm', null),
         MAXIMUM_CAPTURE_AMOUNT: Resource.msg('maximum.capture.amount', 'affirm', null)

--- a/cartridges/bm_affirm/cartridge/static/default/js/transactions.js
+++ b/cartridges/bm_affirm/cartridge/static/default/js/transactions.js
@@ -86,6 +86,9 @@ var tnxs = {
 					} else if (amount > maxCaptureAmt) {
 						errorMsg.textContent = Resources.MAXIMUM_CAPTURE_AMOUNT + " " + maxCaptureAmt
 						return false
+					} else if ( currency != 'USD' && amount != maxCaptureAmt) {
+						errorMsg.textContent = Resources.INVALID_CAPTURE_AMOUNT_PARTIAL
+						return false
 					}
 				}
 

--- a/cartridges/bm_affirm/cartridge/templates/resources/affirm.properties
+++ b/cartridges/bm_affirm/cartridge/templates/resources/affirm.properties
@@ -60,6 +60,7 @@ order.details.label=Order Details
 payment.information.header=Payment Information for Order
 transaction.status=Transaction Status
 capture.amount.validation=Invalid Capture amount
+capture.amount.validation.partial=Partial capture currently not supported
 refund.amount.validation=Invalid Refund amount
 maximum.refund.amount=Maximum Refund amount:
 maximum.capture.amount=Maximum Capture amount:


### PR DESCRIPTION
Disallows the transactions management module from capturing partial amounts when currency is not USD:

![Screen Shot 2022-07-19 at 1 32 36 PM](https://user-images.githubusercontent.com/9426310/179843000-8ee3f98f-c8d6-4fee-be2a-a925fb0c5e9e.png)

Note: This commit only affects the frontend logic (via input validation), as the backend error when attempting partial capture for non-USD loans is handled properly, if for any reason the input validation did not work as intended. 