### PR TITLE
Sets default locale

### DIFF
--- a/cartridges/int_affirm_controllers/cartridge/templates/default/affirm/affirmcheckout.isml
+++ b/cartridges/int_affirm_controllers/cartridge/templates/default/affirm/affirmcheckout.isml
@@ -2,7 +2,7 @@
 <isset name="affirm" value="${require('*/cartridge/scripts/affirm')}" scope="page" />
 <isset name="sfraFlag" value="${false}" scope="page" />
 <isset name="sgControllersFlag" value="${true}" scope="page" />
-<isset name="locale" value="${pdict.CurrentRequest.getLocale() || 'en_US'}" scope="page" />
+<isset name="locale" value="${(empty(pdict.CurrentRequest.getLocale()) || pdict.CurrentRequest.getLocale() == 'default') ? 'en_US' : pdict.CurrentRequest.getLocale()}" scope="page" />
 <script>
   var _affirm_config = {
     public_api_key:  "${affirm.data.getPublicKey()}",

--- a/cartridges/int_affirm_controllers/cartridge/templates/default/affirm/affirmcheckout.isml
+++ b/cartridges/int_affirm_controllers/cartridge/templates/default/affirm/affirmcheckout.isml
@@ -2,12 +2,13 @@
 <isset name="affirm" value="${require('*/cartridge/scripts/affirm')}" scope="page" />
 <isset name="sfraFlag" value="${false}" scope="page" />
 <isset name="sgControllersFlag" value="${true}" scope="page" />
+<isset name="locale" value="${pdict.CurrentRequest.getLocale() || 'en_US'}" scope="page" />
 <script>
   var _affirm_config = {
     public_api_key:  "${affirm.data.getPublicKey()}",
     script:          "${affirm.data.getJSPath()}",
 	session_id:		 "${session.sessionID}",
-	locale: 		 "${pdict.CurrentRequest.getLocale()}",
+	locale: 		 "${locale}",
 	country_code: 	 "${affirm.data.getCountryCode()}"
   };
   (function(l,g,m,e,a,f,b){var d,c=l[m]||{},h=document.createElement(f),n=document.getElementsByTagName(f)[0],k=function(a,b,c){return function(){a[b]._.push([c,arguments])}};c[e]=k(c,e,"set");d=c[e];c[a]={};c[a]._=[];d._=[];c[a][b]=k(c,a,b);a=0;for(b="set add save post open empty reset on off trigger ready setProduct".split(" ");a<b.length;a++)d[b[a]]=k(c,e,b[a]);a=0;for(b=["get","token","url","items"];a<b.length;a++)d[b[a]]=function(){};h.async=!0;h.src=g[f];n.parentNode.insertBefore(h,n);delete g[f];d(g);l[m]=c})(window,_affirm_config,"affirm","checkout","ui","script","ready");

--- a/cartridges/int_affirm_controllers/cartridge/templates/default/affirm/affirmheader.isml
+++ b/cartridges/int_affirm_controllers/cartridge/templates/default/affirm/affirmheader.isml
@@ -1,12 +1,13 @@
 <!--- TEMPLATENAME: affirmheader.isml --->
 <isset name="affirm" value="${require('*/cartridge/scripts/affirm')}" scope="page" />
+<isset name="locale" value="${pdict.CurrentRequest.getLocale() || 'en_US'}" scope="page" />
 <isif condition="${affirm.data.getAffirmOnlineStatus()}">
 	<script>
 	  var _affirm_config = {
 	    public_api_key:  "${affirm.data.getPublicKey()}",
 	    script:          "${affirm.data.getJSPath()}",
 	    session_id:		 "${session.sessionID}",
-		locale: 		 "${pdict.CurrentRequest.getLocale()}",
+		locale: 		 "${locale}",
 		country_code: 	 "${affirm.data.getCountryCode()}"
 	  };
 	  (function(l,g,m,e,a,f,b){var d,c=l[m]||{},h=document.createElement(f),n=document.getElementsByTagName(f)[0],k=function(a,b,c){return function(){a[b]._.push([c,arguments])}};c[e]=k(c,e,"set");d=c[e];c[a]={};c[a]._=[];d._=[];c[a][b]=k(c,a,b);a=0;for(b="set add save post open empty reset on off trigger ready setProduct".split(" ");a<b.length;a++)d[b[a]]=k(c,e,b[a]);a=0;for(b=["get","token","url","items"];a<b.length;a++)d[b[a]]=function(){};h.async=!0;h.src=g[f];n.parentNode.insertBefore(h,n);delete g[f];d(g);l[m]=c})(window,_affirm_config,"affirm","checkout","ui","script","ready");

--- a/cartridges/int_affirm_controllers/cartridge/templates/default/affirm/affirmheader.isml
+++ b/cartridges/int_affirm_controllers/cartridge/templates/default/affirm/affirmheader.isml
@@ -1,6 +1,6 @@
 <!--- TEMPLATENAME: affirmheader.isml --->
 <isset name="affirm" value="${require('*/cartridge/scripts/affirm')}" scope="page" />
-<isset name="locale" value="${pdict.CurrentRequest.getLocale() || 'en_US'}" scope="page" />
+<isset name="locale" value="${(empty(pdict.CurrentRequest.getLocale()) || pdict.CurrentRequest.getLocale() == 'default') ? 'en_US' : pdict.CurrentRequest.getLocale()}" scope="page" />
 <isif condition="${affirm.data.getAffirmOnlineStatus()}">
 	<script>
 	  var _affirm_config = {

--- a/cartridges/int_affirm_pipelines/cartridge/templates/default/affirm/affirmcheckout.isml
+++ b/cartridges/int_affirm_pipelines/cartridge/templates/default/affirm/affirmcheckout.isml
@@ -1,6 +1,6 @@
 <!--- TEMPLATENAME: affirmcheckout.isml --->
 <isset name="affirm" value="${require('*/cartridge/scripts/affirm')}" scope="page" />
-<isset name="locale" value="${pdict.CurrentRequest.getLocale() || 'en_US'}" scope="page" />
+<isset name="locale" value="${(empty(pdict.CurrentRequest.getLocale()) || pdict.CurrentRequest.getLocale() == 'default') ? 'en_US' : pdict.CurrentRequest.getLocale()}" scope="page" />
 <script>
   var _affirm_config = {
     public_api_key:  "${affirm.data.getPublicKey()}",

--- a/cartridges/int_affirm_pipelines/cartridge/templates/default/affirm/affirmcheckout.isml
+++ b/cartridges/int_affirm_pipelines/cartridge/templates/default/affirm/affirmcheckout.isml
@@ -1,11 +1,12 @@
 <!--- TEMPLATENAME: affirmcheckout.isml --->
 <isset name="affirm" value="${require('*/cartridge/scripts/affirm')}" scope="page" />
+<isset name="locale" value="${pdict.CurrentRequest.getLocale() || 'en_US'}" scope="page" />
 <script>
   var _affirm_config = {
     public_api_key:  "${affirm.data.getPublicKey()}",
     script:          "${affirm.data.getJSPath()}",
 	session_id:		 "${session.sessionID}",
-	locale: 		 "${pdict.CurrentRequest.getLocale()}",
+	locale: 		 "${locale}",
 	country_code: 	 "${affirm.data.getCountryCode()}"
   };
   (function(l,g,m,e,a,f,b){var d,c=l[m]||{},h=document.createElement(f),n=document.getElementsByTagName(f)[0],k=function(a,b,c){return function(){a[b]._.push([c,arguments])}};c[e]=k(c,e,"set");d=c[e];c[a]={};c[a]._=[];d._=[];c[a][b]=k(c,a,b);a=0;for(b="set add save post open empty reset on off trigger ready setProduct".split(" ");a<b.length;a++)d[b[a]]=k(c,e,b[a]);a=0;for(b=["get","token","url","items"];a<b.length;a++)d[b[a]]=function(){};h.async=!0;h.src=g[f];n.parentNode.insertBefore(h,n);delete g[f];d(g);l[m]=c})(window,_affirm_config,"affirm","checkout","ui","script","ready");

--- a/cartridges/int_affirm_pipelines/cartridge/templates/default/affirm/affirmheader.isml
+++ b/cartridges/int_affirm_pipelines/cartridge/templates/default/affirm/affirmheader.isml
@@ -1,6 +1,6 @@
 <!--- TEMPLATENAME: affirmheader.isml --->
 <isset name="affirm" value="${require('*/cartridge/scripts/affirm')}" scope="page" />
-<isset name="locale" value="${pdict.CurrentRequest.getLocale() || 'en_US'}" scope="page" />
+<isset name="locale" value="${(empty(pdict.CurrentRequest.getLocale()) || pdict.CurrentRequest.getLocale() == 'default') ? 'en_US' : pdict.CurrentRequest.getLocale()}" scope="page" />
 <isif condition="${affirm.data.getAffirmOnlineStatus()}">
 	<script>
 	  var _affirm_config = {

--- a/cartridges/int_affirm_pipelines/cartridge/templates/default/affirm/affirmheader.isml
+++ b/cartridges/int_affirm_pipelines/cartridge/templates/default/affirm/affirmheader.isml
@@ -1,12 +1,13 @@
 <!--- TEMPLATENAME: affirmheader.isml --->
 <isset name="affirm" value="${require('*/cartridge/scripts/affirm')}" scope="page" />
+<isset name="locale" value="${pdict.CurrentRequest.getLocale() || 'en_US'}" scope="page" />
 <isif condition="${affirm.data.getAffirmOnlineStatus()}">
 	<script>
 	  var _affirm_config = {
 	    public_api_key:  "${affirm.data.getPublicKey()}",
 	    script:          "${affirm.data.getJSPath()}",
 	    session_id:      "${session.sessionID}",
-		locale: 		 "${pdict.CurrentRequest.getLocale()}",
+		locale: 		 "${locale}",
 		country_code: 	 "${affirm.data.getCountryCode()}"
 	  };
 	  (function(l,g,m,e,a,f,b){var d,c=l[m]||{},h=document.createElement(f),n=document.getElementsByTagName(f)[0],k=function(a,b,c){return function(){a[b]._.push([c,arguments])}};c[e]=k(c,e,"set");d=c[e];c[a]={};c[a]._=[];d._=[];c[a][b]=k(c,a,b);a=0;for(b="set add save post open empty reset on off trigger ready setProduct".split(" ");a<b.length;a++)d[b[a]]=k(c,e,b[a]);a=0;for(b=["get","token","url","items"];a<b.length;a++)d[b[a]]=function(){};h.async=!0;h.src=g[f];n.parentNode.insertBefore(h,n);delete g[f];d(g);l[m]=c})(window,_affirm_config,"affirm","checkout","ui","script","ready");

--- a/cartridges/int_affirm_sfra/cartridge/templates/default/affirm/affirmCheckoutMF.isml
+++ b/cartridges/int_affirm_sfra/cartridge/templates/default/affirm/affirmCheckoutMF.isml
@@ -1,6 +1,6 @@
 <!--- TEMPLATENAME: affirmcheckout.isml --->
 <isset name="affirm" value="${require('*/cartridge/scripts/affirm')}" scope="page" />
-<isset name="locale" value="${pdict.CurrentRequest.getLocale() || 'en_US'}" scope="page" />
+<isset name="locale" value="${(empty(pdict.CurrentRequest.getLocale()) || pdict.CurrentRequest.getLocale() == 'default') ? 'en_US' : pdict.CurrentRequest.getLocale()}" scope="page" />
 <script>
   var _affirm_config = {
     public_api_key:  "${affirm.data.getPublicKey()}",

--- a/cartridges/int_affirm_sfra/cartridge/templates/default/affirm/affirmCheckoutMF.isml
+++ b/cartridges/int_affirm_sfra/cartridge/templates/default/affirm/affirmCheckoutMF.isml
@@ -1,11 +1,12 @@
 <!--- TEMPLATENAME: affirmcheckout.isml --->
 <isset name="affirm" value="${require('*/cartridge/scripts/affirm')}" scope="page" />
+<isset name="locale" value="${pdict.CurrentRequest.getLocale() || 'en_US'}" scope="page" />
 <script>
   var _affirm_config = {
     public_api_key:  "${affirm.data.getPublicKey()}",
     script:          "${affirm.data.getJSPath()}",
 	session_id:		 "${session.sessionID}",
-	locale: 		 "${pdict.CurrentRequest.getLocale()}",
+	locale: 		 "${locale}",
 	country_code: 	 "${affirm.data.getCountryCode()}"
   };
   (function(l,g,m,e,a,f,b){var d,c=l[m]||{},h=document.createElement(f),n=document.getElementsByTagName(f)[0],k=function(a,b,c){return function(){a[b]._.push([c,arguments])}};c[e]=k(c,e,"set");d=c[e];c[a]={};c[a]._=[];d._=[];c[a][b]=k(c,a,b);a=0;for(b="set add save post open empty reset on off trigger ready setProduct".split(" ");a<b.length;a++)d[b[a]]=k(c,e,b[a]);a=0;for(b=["get","token","url","items"];a<b.length;a++)d[b[a]]=function(){};h.async=!0;h.src=g[f];n.parentNode.insertBefore(h,n);delete g[f];d(g);l[m]=c})(window,_affirm_config,"affirm","checkout","ui","script","ready");

--- a/cartridges/int_affirm_sfra/cartridge/templates/default/affirm/affirmHeaderMF.isml
+++ b/cartridges/int_affirm_sfra/cartridge/templates/default/affirm/affirmHeaderMF.isml
@@ -1,6 +1,6 @@
 <!--- TEMPLATENAME: affirmHeaderMF.isml --->
 <isset name="affirm" value="${require('*/cartridge/scripts/affirm')}" scope="page" />
-<isset name="locale" value="${pdict.CurrentRequest.getLocale() || 'en_US'}" scope="page" />
+<isset name="locale" value="${(empty(pdict.CurrentRequest.getLocale()) || pdict.CurrentRequest.getLocale() == 'default') ? 'en_US' : pdict.CurrentRequest.getLocale()}" scope="page" />
 <isif condition="${affirm.data.getAffirmOnlineStatus()}">
 	<script>
 	  var _affirm_config = {

--- a/cartridges/int_affirm_sfra/cartridge/templates/default/affirm/affirmHeaderMF.isml
+++ b/cartridges/int_affirm_sfra/cartridge/templates/default/affirm/affirmHeaderMF.isml
@@ -1,12 +1,13 @@
 <!--- TEMPLATENAME: affirmHeaderMF.isml --->
 <isset name="affirm" value="${require('*/cartridge/scripts/affirm')}" scope="page" />
+<isset name="locale" value="${pdict.CurrentRequest.getLocale() || 'en_US'}" scope="page" />
 <isif condition="${affirm.data.getAffirmOnlineStatus()}">
 	<script>
 	  var _affirm_config = {
 	    public_api_key:  "${affirm.data.getPublicKey()}",
 	    script:          "${affirm.data.getJSPath()}",
 	    session_id:		 "${session.sessionID}",
-		locale: 		 "${pdict.CurrentRequest.getLocale()}",
+		locale: 		 "${locale}",
 		country_code: 	 "${affirm.data.getCountryCode()}"
 	  };
 	  (function(l,g,m,e,a,f,b){var d,c=l[m]||{},h=document.createElement(f),n=document.getElementsByTagName(f)[0],k=function(a,b,c){return function(){a[b]._.push([c,arguments])}};c[e]=k(c,e,"set");d=c[e];c[a]={};c[a]._=[];d._=[];c[a][b]=k(c,a,b);a=0;for(b="set add save post open empty reset on off trigger ready setProduct".split(" ");a<b.length;a++)d[b[a]]=k(c,e,b[a]);a=0;for(b=["get","token","url","items"];a<b.length;a++)d[b[a]]=function(){};h.async=!0;h.src=g[f];n.parentNode.insertBefore(h,n);delete g[f];d(g);l[m]=c})(window,_affirm_config,"affirm","checkout","ui","script","ready");


### PR DESCRIPTION
### Summary of the changes
When no locale is set in the configurations of back office in SFCC, the `pdict.CurrentRequest.getLocale` method returns a 'default' string. This PR changes the template to assign `en_US` as the fallback locale when 'default' or a null gets returned. 