### PR TITLE
Update sandbox URL

### DIFF
--- a/cartridges/int_affirm/cartridge/templates/resources/affirm.properties
+++ b/cartridges/int_affirm/cartridge/templates/resources/affirm.properties
@@ -6,7 +6,7 @@ affirm.production.url=https://api.global.affirm.com/api
 affirm.production.js=
 affirm.production.static.js=/affirm/js/live.js
 
-affirm.sandbox.url=https://api.global-sandbox.affirm.com/api
+affirm.sandbox.url=https://api.global.sandbox.affirm.com/api
 affirm.sandbox.js=
 affirm.sandbox.static.js=/affirm/js/sandbox.js
 

--- a/cartridges/int_affirm/cartridge/templates/resources/affirm_en_AU.properties
+++ b/cartridges/int_affirm/cartridge/templates/resources/affirm_en_AU.properties
@@ -6,7 +6,7 @@ affirm.production.url=https://api.global.affirm.com/api
 affirm.production.js=
 affirm.production.static.js=/affirm/js/live.js
 
-affirm.sandbox.url=https://api.global-sandbox.affirm.com/api
+affirm.sandbox.url=https://api.global.sandbox.affirm.com/api
 affirm.sandbox.js=
 affirm.sandbox.static.js=/affirm/js/sandbox.js
 

--- a/cartridges/int_affirm/cartridge/templates/resources/affirm_fr_CA.properties
+++ b/cartridges/int_affirm/cartridge/templates/resources/affirm_fr_CA.properties
@@ -6,7 +6,7 @@ affirm.production.url=https://api.global.affirm.com/api
 affirm.production.js=
 affirm.production.static.js=/affirm/js/live.js
 
-affirm.sandbox.url=https://api.global-sandbox.affirm.com/api
+affirm.sandbox.url=https://api.global.sandbox.affirm.com/api
 affirm.sandbox.js=
 affirm.sandbox.static.js=/affirm/js/sandbox.js
 


### PR DESCRIPTION
As part of the Cloudflare migration, we are updating the global sandbox URL from `api.global-sandbox.affirm.com` to `api.global.sandbox.affirm.com`. The endpoints should otherwise be identical.