### PR TITLE
PSE-3283: Fix confirm page void issue

### DIFF
--- a/cartridges/int_affirm_sfra/cartridge/controllers/Affirm.js
+++ b/cartridges/int_affirm_sfra/cartridge/controllers/Affirm.js
@@ -194,8 +194,13 @@ server.use('Confirmation', function (req, res, next) {
             return next();
         }
 
-        var OrderMgr = require('dw/order/OrderMgr');
-        var order = OrderMgr.createOrder(basket);
+        try {
+            var OrderMgr = require('dw/order/OrderMgr');
+            var order = OrderMgr.createOrder(basket);
+        } catch (e) {
+            var Logger = require('dw/system/Logger').getLogger('affirm', 'affirm');
+            Logger.error('Affirm: Order creation not possible for this basket. Error - {0}', e);
+        }
 
         if (!order) {
             res.redirect(URLUtils.url('Cart-Show').toString());

--- a/cartridges/int_affirm_sfra/cartridge/scripts/checkout/checkoutAffirm.js
+++ b/cartridges/int_affirm_sfra/cartridge/scripts/checkout/checkoutAffirm.js
@@ -65,7 +65,7 @@ affirmCheckout.checkCart = function (basket, checkoutToken, session) {
             };
         }
         var affirmStatus = affirm.basket.syncBasket(basket, affirmResponse.response);
-        if (affirmStatus.error) {
+        if (affirmStatus.error && basket.totalGrossPrice.value > 0) {
             affirmTracker.trackErrorWithoutStack('auth', 'Basket changed error', affirmTracker.INVALID_AMOUNT);
             affirm.order.voidOrder(affirmResponse.response.id);
             return {


### PR DESCRIPTION
This fixes [PSE-3283](https://affirm.atlassian.net/browse/PSE-3283) by adding a check to the basket amount value from a refreshed confirmation page post checkout redirect. 

[PSE-3283]: https://affirm.atlassian.net/browse/PSE-3283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ