### PR TITLE
Redirect to Order-Confirm

### DIFF
--- a/cartridges/int_affirm_sfra/cartridge/controllers/Affirm.js
+++ b/cartridges/int_affirm_sfra/cartridge/controllers/Affirm.js
@@ -228,10 +228,6 @@ server.use('Confirmation', function (req, res, next) {
         checkoutAffirm.postProcess(order);
         COHelpers.sendConfirmationEmail(order, req.locale.id);
 
-        var config = {
-            numberOfLineItems: '*'
-        };
-        var orderModel = new OrderModel(order, { config: config });
         res.redirect(URLUtils.url('Order-Confirm', 'ID', order.orderNo, 'token', order.orderToken).toString());
         return next();
     } catch (e) {

--- a/cartridges/int_affirm_sfra/cartridge/controllers/Affirm.js
+++ b/cartridges/int_affirm_sfra/cartridge/controllers/Affirm.js
@@ -232,20 +232,7 @@ server.use('Confirmation', function (req, res, next) {
             numberOfLineItems: '*'
         };
         var orderModel = new OrderModel(order, { config: config });
-        if (!req.currentCustomer.profile) {
-            var passwordForm = server.forms.getForm('newPasswords');
-            passwordForm.clear();
-            res.render('checkout/confirmation/confirmation', {
-                order: orderModel,
-                returningCustomer: false,
-                passwordForm: passwordForm
-            });
-        } else {
-            res.render('checkout/confirmation/confirmation', {
-                order: orderModel,
-                returningCustomer: true
-            });
-        }
+        res.redirect(URLUtils.url('Order-Confirm', 'ID', order.orderNo, 'token', order.orderToken).toString());
         return next();
     } catch (e) {
         var Logger = require('dw/system/Logger').getLogger('affirm', 'affirm');


### PR DESCRIPTION
This PR updates the `Affirm-Confirmation` endpoint to redirect to the built-in `Order-Confirm` endpoint instead of rendering the confirmation template directly. It passes the necessary query string parameters (`ID` and `token`) to ensure proper order confirmation handling by the storefront. 

This fix addresses Issue #89  by ensuring that the Affirm confirmation redirect URL does not get exposed to duplicate hits when a customer refreshes or revisits the page.